### PR TITLE
Add controls to header

### DIFF
--- a/packages/app/components/Modal/Modal.stories.tsx
+++ b/packages/app/components/Modal/Modal.stories.tsx
@@ -3,6 +3,11 @@ import { Story } from '@storybook/react'
 import { Text } from '../typography/Text'
 import Modal, { ModalProps } from './Modal'
 
+const defaultHeader = <Text size='3XL' color='white'>Welcome to <b>Statemine</b> Asset Creator!</Text>
+const empty = <></>
+
+const headers = { defaultHeader, empty }
+
 const Default = {
   title: 'Components/Modal',
   component: Modal,
@@ -15,9 +20,18 @@ const Default = {
       control: { type: 'select' },
       options: ['m', 'l'],
     },
-    isOpen: true,
-    titleCenterPosition: false,
-    headerOverModal: <Text size='3XL' color='white'>Welcome to <b>Statemine</b> Asset Creator!</Text>
+    headerOverModal: {
+      options: Object.keys(headers),
+      mapping: headers,
+      control: {
+        type: 'select',
+        labels: {
+          defaultModalHeader: 'default header',
+          empty: ''
+        },
+      },
+      defaultValue: 'defaultHeader'
+    },
   }
 }
 
@@ -35,5 +49,5 @@ Base.args = {
   title: 'Modal title',
   titleCenterPosition: false,
   isOpen: true,
-  headerOverModal: <Text size='3XL' color='white'>Welcome to <b>Statemine</b> Asset Creator!</Text>
+  headerOverModal: 'defaultHeader'
 }


### PR DESCRIPTION
This pr adds controls to React.Node elements, so that we don't encounter ugly setObject control with error
![image](https://user-images.githubusercontent.com/30404388/139052126-356d9c7a-32cf-4b3d-b113-efc526be0456.png)
